### PR TITLE
fix: update version of TestableIO.System.IO.Abstractions to "17.*"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup .NET Core 2.1
-        uses: actions/setup-dotnet@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: "2.1.x"
-      - name: Setup .NET Core 3.1
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: "3.1.x"
+          dotnet-version: | 
+            3.1.x
+            5.0.x
+            6.0.x
       - name: Setup .NET
         uses: actions/setup-dotnet@v2
       - name: Run tests

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
     <DefineConstants Condition="'$(TargetFramework)' == 'net5.0'">$(DefineConstants);FEATURE_FILE_SYSTEM_WATCHER_FILTERS</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.IO.Abstractions" Version="17.*" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions" Version="17.*" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.255">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
     <DefineConstants Condition="'$(TargetFramework)' == 'net5.0'">$(DefineConstants);FEATURE_FILE_SYSTEM_WATCHER_FILTERS</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.IO.Abstractions" Version="13.*" />
+    <PackageReference Include="System.IO.Abstractions" Version="17.*" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.255">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100",
-    "rollForward": "latestFeature"
+    "version": "6.0.403",
+    "rollForward": "latestMinor"
   }
 }

--- a/src/System.IO.Abstractions.Extensions/IDirectoryInfoExtensions.cs
+++ b/src/System.IO.Abstractions.Extensions/IDirectoryInfoExtensions.cs
@@ -10,7 +10,7 @@
         /// <returns>An <see cref="IDirectoryInfo"/> for the specified sub-directory</returns>
         public static IDirectoryInfo SubDirectory(this IDirectoryInfo info, string name)
         {
-            return info.FileSystem.DirectoryInfo.FromDirectoryName(info.FileSystem.Path.Combine(info.FullName, name));
+            return info.FileSystem.DirectoryInfo.New(info.FileSystem.Path.Combine(info.FullName, name));
         }
 
         /// <summary>
@@ -21,7 +21,7 @@
         /// <returns>An <see cref="IFileInfo"/> for the specified file</returns>
         public static IFileInfo File(this IDirectoryInfo info, string name)
         {
-            return info.FileSystem.FileInfo.FromFileName(info.FileSystem.Path.Combine(info.FullName, name));
+            return info.FileSystem.FileInfo.New(info.FileSystem.Path.Combine(info.FullName, name));
         }
     }
 }

--- a/src/System.IO.Abstractions.Extensions/IFileSystemExtensions.cs
+++ b/src/System.IO.Abstractions.Extensions/IFileSystemExtensions.cs
@@ -9,7 +9,7 @@
         /// <returns>An <see cref="IDirectoryInfo"/> for the current directory</returns>
         public static IDirectoryInfo CurrentDirectory(this IFileSystem fileSystem)
         {
-            return fileSystem.DirectoryInfo.FromDirectoryName(fileSystem.Directory.GetCurrentDirectory());
+            return fileSystem.DirectoryInfo.New(fileSystem.Directory.GetCurrentDirectory());
         }
     }
 }

--- a/src/System.IO.Abstractions.Extensions/System.IO.Abstractions.Extensions.csproj
+++ b/src/System.IO.Abstractions.Extensions/System.IO.Abstractions.Extensions.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <PackageId>TestableIO.System.IO.Abstractions.Extensions</PackageId>
-    <TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
-    <Description>Convenience functionalities on top of System.IO.Abstractions</Description>
-  </PropertyGroup>
+	<PropertyGroup>
+		<PackageId>TestableIO.System.IO.Abstractions.Extensions</PackageId>
+		<TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
+		<Description>Convenience functionalities on top of System.IO.Abstractions</Description>
+	</PropertyGroup>
 
 </Project>

--- a/src/System.IO.Abstractions.Extensions/System.IO.Abstractions.Extensions.csproj
+++ b/src/System.IO.Abstractions.Extensions/System.IO.Abstractions.Extensions.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <PackageId>TestableIO.System.IO.Abstractions.Extensions</PackageId>
-    <TargetFrameworks>net5.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
     <Description>Convenience functionalities on top of System.IO.Abstractions</Description>
   </PropertyGroup>
 

--- a/tests/System.IO.Abstractions.Extensions.Tests/DirectoryInfoExtensionsTests.cs
+++ b/tests/System.IO.Abstractions.Extensions.Tests/DirectoryInfoExtensionsTests.cs
@@ -10,7 +10,7 @@ namespace System.IO.Abstractions.Tests
         {
             //arrange
             var fs = new FileSystem();
-            var current =  fs.DirectoryInfo.FromDirectoryName(fs.Directory.GetCurrentDirectory());
+            var current =  fs.DirectoryInfo.New(fs.Directory.GetCurrentDirectory());
             var guid = Guid.NewGuid().ToString();
             var expectedPath = fs.Path.Combine(current.FullName, guid);
 
@@ -35,7 +35,7 @@ namespace System.IO.Abstractions.Tests
         {
             //arrange
             var fs = new FileSystem();
-            var current = fs.DirectoryInfo.FromDirectoryName(fs.Directory.GetCurrentDirectory());
+            var current = fs.DirectoryInfo.New(fs.Directory.GetCurrentDirectory());
             var guid = Guid.NewGuid().ToString();
             var expectedPath = fs.Path.Combine(current.FullName, guid);
 

--- a/tests/System.IO.Abstractions.Extensions.Tests/System.IO.Abstractions.Extensions.Tests.csproj
+++ b/tests/System.IO.Abstractions.Extensions.Tests/System.IO.Abstractions.Extensions.Tests.csproj
@@ -1,14 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="!$([MSBuild]::IsOsUnixLike())">$(TargetFrameworks);net461</TargetFrameworks>
-    <IsPackable>false</IsPackable>
-    <IsTestable>true</IsTestable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks Condition="!$([MSBuild]::IsOsUnixLike())">$(TargetFrameworks);net461</TargetFrameworks>
+		<IsPackable>false</IsPackable>
+		<IsTestable>true</IsTestable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\System.IO.Abstractions.Extensions\System.IO.Abstractions.Extensions.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="17.*" />
+		<ProjectReference Include="..\..\src\System.IO.Abstractions.Extensions\System.IO.Abstractions.Extensions.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/tests/System.IO.Abstractions.Extensions.Tests/System.IO.Abstractions.Extensions.Tests.csproj
+++ b/tests/System.IO.Abstractions.Extensions.Tests/System.IO.Abstractions.Extensions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition="!$([MSBuild]::IsOsUnixLike())">$(TargetFrameworks);net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestable>true</IsTestable>


### PR DESCRIPTION
As mentioned [in this comment](https://github.com/TestableIO/System.IO.Abstractions/pull/905#issuecomment-1327627295) the Extensions project no longer compiles with the latest version of System.IO.Abstractions.

Also use the same `global.json` and target frameworks as in the "System.IO.Abstractions" projects.