### PR TITLE
feat: Add extension to IFileSystem to allow using pattern to delete files / directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ using (var stream = current.FileSystem.FileInfo.FromFileName(current.FileSystem.
 
 ## Automatic cleanup with Disposable extensions
 
+Use `CreateDisposableDirectory` or `CreateDisposableFile` to create a `IDirectoryInfo` or `IFileInfo` that's automatically
+deleted when the returned `IDisposable` is disposed.
+
 ```csharp
 var fs = new FileSystem();
 
@@ -63,9 +66,9 @@ using (fs.CreateDisposableDirectory(out IDirectoryInfo dir))
 }
 
 //without extension
-var temp = fileSystem.Path.GetTempPath();
-var fileName = fileSystem.Path.GetRandomFileName();
-var path = fileSystem.Path.Combine(temp, fileName);
+var temp = fs.Path.GetTempPath();
+var fileName = fs.Path.GetRandomFileName();
+var path = fs.Path.Combine(temp, fileName);
 
 try
 {

--- a/README.md
+++ b/README.md
@@ -50,3 +50,30 @@ using (var stream = current.File("test.txt").Create())
 using (var stream = current.FileSystem.FileInfo.FromFileName(current.FileSystem.Path.Combine(current.FullName, "test.txt")).Create())
     stream.Dispose();
 ```
+
+## CreateDisposableDirectory / CreateDisposableFile extension
+
+```csharp
+var fs = new FileSystem();
+
+//with extension
+using (fs.CreateDisposableDirectory(out IDirectoryInfo dir))
+{
+    Console.WriteLine($"This directory will be deleted when control leaves the using block: '{dir.FullName}'");
+}
+
+//without extension
+var temp = fileSystem.Path.GetTempPath();
+var fileName = fileSystem.Path.GetRandomFileName();
+var path = fileSystem.Path.Combine(temp, fileName);
+
+try
+{
+    IDirectoryInfo dir = fs.Directory.CreateDirectory(path);
+    Console.WriteLine($"This directory will be deleted in the finally block: '{dir.FullName}'");
+}
+finally
+{
+    fs.Directory.Delete(path, recursive: true);
+}
+```

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ using (var stream = current.FileSystem.FileInfo.FromFileName(current.FileSystem.
     stream.Dispose();
 ```
 
-## CreateDisposableDirectory / CreateDisposableFile extension
+## Automatic cleanup with Disposable extensions
 
 ```csharp
 var fs = new FileSystem();

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,12 +11,4 @@
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)..\images\icon_256x256.png" Pack="true" PackagePath="\" />
   </ItemGroup>
-
-  <ItemGroup>
-    <!-- Automatically make internal classes visible to test projects -->
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>$(MSBuildProjectName).Tests</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
-
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,4 +11,12 @@
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)..\images\icon_256x256.png" Pack="true" PackagePath="\" />
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- Automatically make internal classes visible to test projects -->
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>$(MSBuildProjectName).Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/src/System.IO.Abstractions.Extensions/DisposableDirectory.cs
+++ b/src/System.IO.Abstractions.Extensions/DisposableDirectory.cs
@@ -1,0 +1,57 @@
+﻿namespace System.IO.Abstractions.Extensions
+{
+    /// <summary>
+    /// Creates a directory that will be deleted when the <see cref="Dispose()"/> method is called.
+    /// </summary>
+    /// <remarks>
+    /// This class is designed for the <c>using</c> pattern to ensure that a directory is
+    /// created and then deleted when it is no longer referenced. This is sometimes called
+    /// the RAII pattern (see https://en.wikipedia.org/wiki/Resource_acquisition_is_initialization).
+    /// </remarks>
+    public class DisposableDirectory : IDisposable
+    {
+        private bool isDisposed;
+        private readonly IDirectoryInfo directoryInfo;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DisposableDirectory"/> class.
+        /// </summary>
+        /// <param name="directoryInfo">
+        /// The directory to delete when this object is disposed.
+        /// </param>
+        public DisposableDirectory(IDirectoryInfo directoryInfo)
+        {
+            this.directoryInfo = directoryInfo ?? throw new ArgumentNullException(nameof(directoryInfo));
+        }
+
+        /// <summary>
+        /// Performs the actual work of releasing resources. This allows for subclasses to participate
+        /// in resource release.
+        /// </summary>
+        /// <param name="disposing">
+        /// <c>true</c> if if the call comes from a <see cref="Dispose()"/> method, <c>false</c> if it
+        /// comes from a finalizer.
+        /// </param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!isDisposed)
+            {
+                if (disposing)
+                {
+                    directoryInfo.Delete(recursive: true);
+                }
+
+                isDisposed = true;
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method.
+            // See https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose.
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/System.IO.Abstractions.Extensions/DisposableDirectory.cs
+++ b/src/System.IO.Abstractions.Extensions/DisposableDirectory.cs
@@ -39,6 +39,10 @@
                 if (disposing)
                 {
                     directoryInfo.Delete(recursive: true);
+
+                    // Do an attribute refresh so that the object we returned to the
+                    // caller has up-to-date properties (like Exists).
+                    directoryInfo.Refresh();
                 }
 
                 isDisposed = true;

--- a/src/System.IO.Abstractions.Extensions/DisposableDirectory.cs
+++ b/src/System.IO.Abstractions.Extensions/DisposableDirectory.cs
@@ -5,7 +5,7 @@
     /// deleted when the <see cref="Dispose()"/> method is called.
     /// </summary>
     /// <inheritdoc/>
-    internal class DisposableDirectory : DisposableFileSystemInfo<IDirectoryInfo>
+    public class DisposableDirectory : DisposableFileSystemInfo<IDirectoryInfo>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DisposableDirectory"/> class.

--- a/src/System.IO.Abstractions.Extensions/DisposableDirectory.cs
+++ b/src/System.IO.Abstractions.Extensions/DisposableDirectory.cs
@@ -1,61 +1,26 @@
 ﻿namespace System.IO.Abstractions.Extensions
 {
     /// <summary>
-    /// Creates a directory that will be deleted when the <see cref="Dispose()"/> method is called.
+    /// Creates a class that wraps a <see cref="IDirectoryInfo"/>. That wrapped directory will be
+    /// deleted when the <see cref="Dispose()"/> method is called.
     /// </summary>
-    /// <remarks>
-    /// This class is designed for the <c>using</c> pattern to ensure that a directory is
-    /// created and then deleted when it is no longer referenced. This is sometimes called
-    /// the RAII pattern (see https://en.wikipedia.org/wiki/Resource_acquisition_is_initialization).
-    /// </remarks>
-    internal class DisposableDirectory : IDisposable
+    /// <inheritdoc/>
+    internal class DisposableDirectory : DisposableFileSystemInfo<IDirectoryInfo>
     {
-        private bool isDisposed;
-        private readonly IDirectoryInfo directoryInfo;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="DisposableDirectory"/> class.
         /// </summary>
         /// <param name="directoryInfo">
         /// The directory to delete when this object is disposed.
         /// </param>
-        public DisposableDirectory(IDirectoryInfo directoryInfo)
+        public DisposableDirectory(IDirectoryInfo directoryInfo) : base(directoryInfo)
         {
-            this.directoryInfo = directoryInfo ?? throw new ArgumentNullException(nameof(directoryInfo));
-        }
-
-        /// <summary>
-        /// Performs the actual work of releasing resources. This allows for subclasses to participate
-        /// in resource release.
-        /// </summary>
-        /// <param name="disposing">
-        /// <c>true</c> if if the call comes from a <see cref="Dispose()"/> method, <c>false</c> if it
-        /// comes from a finalizer.
-        /// </param>
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!isDisposed)
-            {
-                if (disposing)
-                {
-                    directoryInfo.Delete(recursive: true);
-
-                    // Do an attribute refresh so that the object we returned to the
-                    // caller has up-to-date properties (like Exists).
-                    directoryInfo.Refresh();
-                }
-
-                isDisposed = true;
-            }
         }
 
         /// <inheritdoc/>
-        public void Dispose()
+        protected override void DeleteFileSystemInfo()
         {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method.
-            // See https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose.
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
+            fileSystemInfo.Delete(recursive: true);
         }
     }
 }

--- a/src/System.IO.Abstractions.Extensions/DisposableDirectory.cs
+++ b/src/System.IO.Abstractions.Extensions/DisposableDirectory.cs
@@ -8,7 +8,7 @@
     /// created and then deleted when it is no longer referenced. This is sometimes called
     /// the RAII pattern (see https://en.wikipedia.org/wiki/Resource_acquisition_is_initialization).
     /// </remarks>
-    public class DisposableDirectory : IDisposable
+    internal class DisposableDirectory : IDisposable
     {
         private bool isDisposed;
         private readonly IDirectoryInfo directoryInfo;

--- a/src/System.IO.Abstractions.Extensions/DisposableFile.cs
+++ b/src/System.IO.Abstractions.Extensions/DisposableFile.cs
@@ -1,0 +1,57 @@
+﻿namespace System.IO.Abstractions.Extensions
+{
+    /// <summary>
+    /// Creates a file that will be deleted when the <see cref="Dispose()"/> method is called.
+    /// </summary>
+    /// <remarks>
+    /// This class is designed for the <c>using</c> pattern to ensure that a file is
+    /// created and then deleted when it is no longer referenced. This is sometimes called
+    /// the RAII pattern (see https://en.wikipedia.org/wiki/Resource_acquisition_is_initialization).
+    /// </remarks>
+    public class DisposableFile : IDisposable
+    {
+        private bool isDisposed;
+        private readonly IFileInfo fileInfo;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DisposableFile"/> class.
+        /// </summary>
+        /// <param name="fileInfo">
+        /// The file to delete when this object is disposed.
+        /// </param>
+        public DisposableFile(IFileInfo fileInfo)
+        {
+            this.fileInfo = fileInfo ?? throw new ArgumentNullException(nameof(fileInfo));
+        }
+
+        /// <summary>
+        /// Performs the actual work of releasing resources. This allows for subclasses to participate
+        /// in resource release.
+        /// </summary>
+        /// <param name="disposing">
+        /// <c>true</c> if if the call comes from a <see cref="Dispose()"/> method, <c>false</c> if it
+        /// comes from a finalizer.
+        /// </param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!isDisposed)
+            {
+                if (disposing)
+                {
+                    fileInfo.Delete();
+                }
+
+                isDisposed = true;
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method.
+            // See https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose.
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/System.IO.Abstractions.Extensions/DisposableFile.cs
+++ b/src/System.IO.Abstractions.Extensions/DisposableFile.cs
@@ -1,61 +1,20 @@
 ﻿namespace System.IO.Abstractions.Extensions
 {
     /// <summary>
-    /// Creates a file that will be deleted when the <see cref="Dispose()"/> method is called.
+    /// Creates a class that wraps a <see cref="IFileInfo"/>. That wrapped file will be
+    /// deleted when the <see cref="Dispose()"/> method is called.
     /// </summary>
-    /// <remarks>
-    /// This class is designed for the <c>using</c> pattern to ensure that a file is
-    /// created and then deleted when it is no longer referenced. This is sometimes called
-    /// the RAII pattern (see https://en.wikipedia.org/wiki/Resource_acquisition_is_initialization).
-    /// </remarks>
-    internal class DisposableFile : IDisposable
+    /// <inheritdoc/>
+    internal class DisposableFile : DisposableFileSystemInfo<IFileInfo>
     {
-        private bool isDisposed;
-        private readonly IFileInfo fileInfo;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="DisposableFile"/> class.
         /// </summary>
         /// <param name="fileInfo">
         /// The file to delete when this object is disposed.
         /// </param>
-        public DisposableFile(IFileInfo fileInfo)
+        public DisposableFile(IFileInfo fileInfo) : base(fileInfo)
         {
-            this.fileInfo = fileInfo ?? throw new ArgumentNullException(nameof(fileInfo));
-        }
-
-        /// <summary>
-        /// Performs the actual work of releasing resources. This allows for subclasses to participate
-        /// in resource release.
-        /// </summary>
-        /// <param name="disposing">
-        /// <c>true</c> if if the call comes from a <see cref="Dispose()"/> method, <c>false</c> if it
-        /// comes from a finalizer.
-        /// </param>
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!isDisposed)
-            {
-                if (disposing)
-                {
-                    fileInfo.Delete();
-                    
-                    // Do an attribute refresh so that the object we returned to the
-                    // caller has up-to-date properties (like Exists).
-                    fileInfo.Refresh();
-                }
-
-                isDisposed = true;
-            }
-        }
-
-        /// <inheritdoc/>
-        public void Dispose()
-        {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method.
-            // See https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose.
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/System.IO.Abstractions.Extensions/DisposableFile.cs
+++ b/src/System.IO.Abstractions.Extensions/DisposableFile.cs
@@ -39,6 +39,10 @@
                 if (disposing)
                 {
                     fileInfo.Delete();
+                    
+                    // Do an attribute refresh so that the object we returned to the
+                    // caller has up-to-date properties (like Exists).
+                    fileInfo.Refresh();
                 }
 
                 isDisposed = true;

--- a/src/System.IO.Abstractions.Extensions/DisposableFile.cs
+++ b/src/System.IO.Abstractions.Extensions/DisposableFile.cs
@@ -5,7 +5,7 @@
     /// deleted when the <see cref="Dispose()"/> method is called.
     /// </summary>
     /// <inheritdoc/>
-    internal class DisposableFile : DisposableFileSystemInfo<IFileInfo>
+    public class DisposableFile : DisposableFileSystemInfo<IFileInfo>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DisposableFile"/> class.

--- a/src/System.IO.Abstractions.Extensions/DisposableFile.cs
+++ b/src/System.IO.Abstractions.Extensions/DisposableFile.cs
@@ -8,7 +8,7 @@
     /// created and then deleted when it is no longer referenced. This is sometimes called
     /// the RAII pattern (see https://en.wikipedia.org/wiki/Resource_acquisition_is_initialization).
     /// </remarks>
-    public class DisposableFile : IDisposable
+    internal class DisposableFile : IDisposable
     {
         private bool isDisposed;
         private readonly IFileInfo fileInfo;

--- a/src/System.IO.Abstractions.Extensions/DisposableFileSystemInfo.cs
+++ b/src/System.IO.Abstractions.Extensions/DisposableFileSystemInfo.cs
@@ -23,6 +23,10 @@
         public DisposableFileSystemInfo(T fileSystemInfo)
         {
             this.fileSystemInfo = fileSystemInfo ?? throw new ArgumentNullException(nameof(fileSystemInfo));
+
+            // Do an attribute refresh so that the object we return to the caller
+            // has up-to-date properties (like Exists).
+            this.fileSystemInfo.Refresh();
         }
 
         /// <summary>

--- a/src/System.IO.Abstractions.Extensions/DisposableFileSystemInfo.cs
+++ b/src/System.IO.Abstractions.Extensions/DisposableFileSystemInfo.cs
@@ -1,0 +1,74 @@
+﻿namespace System.IO.Abstractions.Extensions
+{
+    /// <summary>
+    /// Creates a class that wraps a <see cref="IFileSystemInfo"/>. That wrapped object will be deleted
+    /// when the <see cref="Dispose()"/> method is called.
+    /// </summary>
+    /// <remarks>
+    /// This class is designed for the <c>using</c> pattern to ensure that a directory is
+    /// created and then deleted when it is no longer referenced. This is sometimes called
+    /// the RAII pattern (see https://en.wikipedia.org/wiki/Resource_acquisition_is_initialization).
+    /// </remarks>
+    internal class DisposableFileSystemInfo<T> : IDisposable where T : IFileSystemInfo
+    {
+        protected T fileSystemInfo;
+        private bool isDisposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DisposableFileSystemInfoBase"/> class.
+        /// </summary>
+        /// <param name="fileSystemInfo">
+        /// The directory to delete when this object is disposed.
+        /// </param>
+        public DisposableFileSystemInfo(T fileSystemInfo)
+        {
+            this.fileSystemInfo = fileSystemInfo ?? throw new ArgumentNullException(nameof(fileSystemInfo));
+        }
+
+        /// <summary>
+        /// Performs the actual work of releasing resources. This allows for subclasses to participate
+        /// in resource release.
+        /// </summary>
+        /// <param name="disposing">
+        /// <c>true</c> if if the call comes from a <see cref="Dispose()"/> method, <c>false</c> if it
+        /// comes from a finalizer.
+        /// </param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!isDisposed)
+            {
+                if (disposing)
+                {
+                    DeleteFileSystemInfo();
+
+                    // Do an attribute refresh so that the object we returned to the
+                    // caller has up-to-date properties (like Exists).
+                    fileSystemInfo.Refresh();
+                }
+
+                isDisposed = true;
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method.
+            // See https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose.
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Deletes the wrapped <typeparamref name="T"/> object.
+        /// </summary>
+        /// <remarks>
+        /// Different types of <typeparamref name="T"/> objects have different ways of deleting themselves (e.g.
+        /// directories usually need to be deleted recursively). This method is called by the <see cref="Dispose()"/>
+        /// </remarks>
+        protected virtual void DeleteFileSystemInfo()
+        {
+            fileSystemInfo.Delete();
+        }
+    }
+}

--- a/src/System.IO.Abstractions.Extensions/DisposableFileSystemInfo.cs
+++ b/src/System.IO.Abstractions.Extensions/DisposableFileSystemInfo.cs
@@ -9,7 +9,7 @@
     /// created and then deleted when it is no longer referenced. This is sometimes called
     /// the RAII pattern (see https://en.wikipedia.org/wiki/Resource_acquisition_is_initialization).
     /// </remarks>
-    internal class DisposableFileSystemInfo<T> : IDisposable where T : IFileSystemInfo
+    public class DisposableFileSystemInfo<T> : IDisposable where T : IFileSystemInfo
     {
         protected T fileSystemInfo;
         private bool isDisposed;

--- a/src/System.IO.Abstractions.Extensions/IFileSystemExtensions.cs
+++ b/src/System.IO.Abstractions.Extensions/IFileSystemExtensions.cs
@@ -27,11 +27,7 @@
         /// </returns>
         public static IDisposable CreateDisposableDirectory(this IFileSystem fileSystem, out IDirectoryInfo directoryInfo)
         {
-            var temp = fileSystem.Path.GetTempPath();
-            var fileName = fileSystem.Path.GetRandomFileName();
-            var path = fileSystem.Path.Combine(temp, fileName);
-
-            return fileSystem.CreateDisposableDirectory(path, out directoryInfo);
+            return fileSystem.CreateDisposableDirectory(fileSystem.GetRandomTempPath(), out directoryInfo);
         }
 
         /// <inheritdoc cref="CreateDisposableDirectory(IFileSystem, out IDirectoryInfo)"/>
@@ -74,11 +70,7 @@
         /// </returns>
         public static IDisposable CreateDisposableFile(this IFileSystem fileSystem, out IFileInfo fileInfo)
         {
-            var temp = fileSystem.Path.GetTempPath();
-            var fileName = fileSystem.Path.GetRandomFileName();
-            var path = fileSystem.Path.Combine(temp, fileName);
-
-            return fileSystem.CreateDisposableFile(path, out fileInfo);
+            return fileSystem.CreateDisposableFile(fileSystem.GetRandomTempPath(), out fileInfo);
         }
 
         /// <inheritdoc cref="CreateDisposableFile(IFileSystem, out IFileInfo)"/>
@@ -106,6 +98,15 @@
             fileInfo.Refresh();
 
             return new DisposableFile(fileInfo);
+        }
+
+        private static string GetRandomTempPath(this IFileSystem fileSystem)
+        {
+            var temp = fileSystem.Path.GetTempPath();
+            var fileName = fileSystem.Path.GetRandomFileName();
+            var path = fileSystem.Path.Combine(temp, fileName);
+
+            return path;
         }
 
         private static ArgumentException CreateAlreadyExistsException(string argumentName, string path)

--- a/src/System.IO.Abstractions.Extensions/IFileSystemExtensions.cs
+++ b/src/System.IO.Abstractions.Extensions/IFileSystemExtensions.cs
@@ -57,13 +57,7 @@
 
             if (directoryInfo.Exists)
             {
-                // Having the colliding path availabe as part of the exception is very useful for debugging.
-                // However, paths can be considered sensitive information in some contexts (like web servers).
-                // Thus, we add the path to the exception's data , rather than the message.
-                var ex = new ArgumentException("Directory already exists", nameof(path));
-                ex.Data.Add("path", path);
-
-                throw ex;
+                throw CreateAlreadyExistsException(nameof(path), path);
             }
 
             directoryInfo.Create();
@@ -73,6 +67,76 @@
             directoryInfo.Refresh();
 
             return new DisposableDirectory(directoryInfo);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="DisposableFile"/> using a random name from the temp path.
+        /// </summary>
+        /// <param name="fileSystem">
+        /// The <see cref="IFileSystem"/> in use.
+        /// </param>
+        /// <param name="fileInfo">
+        /// The <see cref="IFileInfo"/> for the file that was created.
+        /// </param>
+        /// <returns>
+        /// A <see cref="DisposableFile"/> to manage the file's lifetime.
+        /// </returns>
+        public static DisposableFile CreateDisposableFile(this IFileSystem fileSystem, out IFileInfo fileInfo)
+        {
+            var temp = fileSystem.Path.GetTempPath();
+            var fileName = fileSystem.Path.GetRandomFileName();
+            var path = fileSystem.Path.Combine(temp, fileName);
+
+            return fileSystem.CreateDisposableFile(path, out fileInfo);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="DisposableFile"/> using the provided <paramref name="path"/>.
+        /// </summary>
+        /// <param name="fileSystem">
+        /// The <see cref="IFileSystem"/> in use.
+        /// </param>
+        /// <param name="path">
+        /// The full path to the file to create.
+        /// </param>
+        /// <param name="fileInfo">
+        /// The <see cref="IFileInfo"/> for the file that was craeted.
+        /// </param>
+        /// <returns>
+        /// A <see cref="DisposableFile"/> to manage the file's lifetime.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// If the file already exists.
+        /// </exception>
+        public static DisposableFile CreateDisposableFile(this IFileSystem fileSystem, string path, out IFileInfo fileInfo)
+        {
+            fileInfo = fileSystem.FileInfo.New(path);
+
+            if (fileInfo.Exists)
+            {
+                throw CreateAlreadyExistsException(nameof(path), path);
+            }
+
+            // Ensure we close the handle to the file after we create it, otherwise
+            // callers may get an access denied error.
+            fileInfo.Create().Dispose();
+
+            // Do an attribute refresh so that the object we return to the caller
+            // has up-to-date properties (like Exists).
+            fileInfo.Refresh();
+
+            return new DisposableFile(fileInfo);
+        }
+
+        private static ArgumentException CreateAlreadyExistsException(string argumentName, string path)
+        {
+            // Having the colliding path availabe as part of the exception is very useful for debugging.
+            // However, paths can be considered sensitive information in some contexts (like web servers).
+            // Thus, we add the path to the exception's data , rather than the message.
+            var ex = new ArgumentException("File already exists", argumentName);
+            ex.Data.Add("path", path);
+
+            return ex;
         }
     }
 }

--- a/src/System.IO.Abstractions.Extensions/IFileSystemExtensions.cs
+++ b/src/System.IO.Abstractions.Extensions/IFileSystemExtensions.cs
@@ -48,10 +48,6 @@
 
             directoryInfo.Create();
 
-            // Do an attribute refresh so that the object we return to the caller
-            // has up-to-date properties (like Exists).
-            directoryInfo.Refresh();
-
             return new DisposableDirectory(directoryInfo);
         }
 
@@ -92,10 +88,6 @@
             // Ensure we close the handle to the file after we create it, otherwise
             // callers may get an access denied error.
             fileInfo.Create().Dispose();
-
-            // Do an attribute refresh so that the object we return to the caller
-            // has up-to-date properties (like Exists).
-            fileInfo.Refresh();
 
             return new DisposableFile(fileInfo);
         }

--- a/src/System.IO.Abstractions.Extensions/IFileSystemExtensions.cs
+++ b/src/System.IO.Abstractions.Extensions/IFileSystemExtensions.cs
@@ -1,4 +1,13 @@
-﻿namespace System.IO.Abstractions.Extensions
+﻿// S3874: "out" and "ref" parameters should not be used
+// https://rules.sonarsource.com/csharp/RSPEC-3874/
+//
+// Our CreateDisposableDirectory / CreateDisposableFile extensions
+// intentionally use an out param so that the DirectoryInfo / FileInfo
+// is passed out (similar to a Try* method) to the caller while the
+// returned object implements IDisposable to leverage the using statement.
+#pragma warning disable S3874
+
+namespace System.IO.Abstractions.Extensions
 {
     public static class IFileSystemExtensions
     {

--- a/src/System.IO.Abstractions.Extensions/IFileSystemExtensions.cs
+++ b/src/System.IO.Abstractions.Extensions/IFileSystemExtensions.cs
@@ -27,7 +27,7 @@
         /// </returns>
         public static IDisposable CreateDisposableDirectory(this IFileSystem fileSystem, out IDirectoryInfo directoryInfo)
         {
-            return fileSystem.CreateDisposableDirectory(fileSystem.GetRandomTempPath(), out directoryInfo);
+            return fileSystem.CreateDisposableDirectory(fileSystem.Path.GetRandomTempPath(), out directoryInfo);
         }
 
         /// <inheritdoc cref="CreateDisposableDirectory(IFileSystem, out IDirectoryInfo)"/>
@@ -70,7 +70,7 @@
         /// </returns>
         public static IDisposable CreateDisposableFile(this IFileSystem fileSystem, out IFileInfo fileInfo)
         {
-            return fileSystem.CreateDisposableFile(fileSystem.GetRandomTempPath(), out fileInfo);
+            return fileSystem.CreateDisposableFile(fileSystem.Path.GetRandomTempPath(), out fileInfo);
         }
 
         /// <inheritdoc cref="CreateDisposableFile(IFileSystem, out IFileInfo)"/>
@@ -100,13 +100,11 @@
             return new DisposableFile(fileInfo);
         }
 
-        private static string GetRandomTempPath(this IFileSystem fileSystem)
+        private static string GetRandomTempPath(this IPath path)
         {
-            var temp = fileSystem.Path.GetTempPath();
-            var fileName = fileSystem.Path.GetRandomFileName();
-            var path = fileSystem.Path.Combine(temp, fileName);
-
-            return path;
+            var temp = path.GetTempPath();
+            var fileName = path.GetRandomFileName();
+            return path.Combine(temp, fileName);
         }
 
         private static ArgumentException CreateAlreadyExistsException(string argumentName, string path)

--- a/src/System.IO.Abstractions.Extensions/IFileSystemExtensions.cs
+++ b/src/System.IO.Abstractions.Extensions/IFileSystemExtensions.cs
@@ -40,6 +40,10 @@ namespace System.IO.Abstractions.Extensions
         }
 
         /// <inheritdoc cref="CreateDisposableDirectory(IFileSystem, out IDirectoryInfo)"/>
+        /// <summary>
+        /// Creates a new <see cref="IDirectoryInfo"/> using a path provided by <paramref name="path"/>, and returns an
+        /// <see cref="IDisposable"/> that deletes the directory when disposed.
+        /// </summary>
         /// <param name="path">
         /// The full path to the directory to create.
         /// </param>
@@ -52,6 +56,10 @@ namespace System.IO.Abstractions.Extensions
         }
 
         /// <inheritdoc cref="CreateDisposableDirectory(IFileSystem, string, out IDirectoryInfo)"/>
+        /// <summary>
+        /// Creates a new <see cref="IDirectoryInfo"/> using a path provided by <paramref name="path"/>, and returns an
+        /// <see cref="IDisposable"/> created by <paramref name="disposableFactory"/>, that should delete the directory when disposed.
+        /// </summary>
         /// <param name="disposableFactory">
         /// A <see cref="Func{T, TResult}"/> that acts as a factory method. Given the <see cref="IDirectoryInfo"/>, create the
         /// <see cref="IDisposable"/> that will manage the its lifetime.
@@ -93,6 +101,10 @@ namespace System.IO.Abstractions.Extensions
         }
 
         /// <inheritdoc cref="CreateDisposableFile(IFileSystem, out IFileInfo)"/>
+        /// <summary>
+        /// Creates a new <see cref="IFileInfo"/> using a path provided by <paramref name="path"/>, and returns an
+        /// <see cref="IDisposable"/> that deletes the file when disposed.
+        /// </summary>
         /// <param name="path">
         /// The full path to the file to create.
         /// </param>
@@ -105,6 +117,10 @@ namespace System.IO.Abstractions.Extensions
         }
 
         /// <inheritdoc cref="CreateDisposableFile(IFileSystem, string, out IFileInfo)"/>
+        /// <summary>
+        /// Creates a new <see cref="IFileInfo"/> using a path provided by <paramref name="path"/>, and returns an
+        /// <see cref="IDisposable"/> created by <paramref name="disposableFactory"/>, that should delete the file when disposed.
+        /// </summary>
         /// <param name="disposableFactory">
         /// A <see cref="Func{T, TResult}"/> that acts as a factory method. Given the <see cref="IFileInfo"/>, create the
         /// <see cref="IDisposable"/> that will manage the its lifetime.

--- a/src/System.IO.Abstractions.Extensions/IFileSystemExtensions.cs
+++ b/src/System.IO.Abstractions.Extensions/IFileSystemExtensions.cs
@@ -11,5 +11,68 @@
         {
             return fileSystem.DirectoryInfo.New(fileSystem.Directory.GetCurrentDirectory());
         }
+
+        /// <summary>
+        /// Creates a new <see cref="DisposableDirectory"/> using a random name from the temp path.
+        /// </summary>
+        /// <param name="fileSystem">
+        /// The <see cref="IFileSystem"/> in use.
+        /// </param>
+        /// <param name="directoryInfo">
+        /// The <see cref="IDirectoryInfo"/> for the directory that was created.
+        /// </param>
+        /// <returns>
+        /// A <see cref="DisposableDirectory"/> to manage the directory's lifetime.
+        /// </returns>
+        public static DisposableDirectory CreateDisposableDirectory(this IFileSystem fileSystem, out IDirectoryInfo directoryInfo)
+        {
+            var temp = fileSystem.Path.GetTempPath();
+            var fileName = fileSystem.Path.GetRandomFileName();
+            var path = fileSystem.Path.Combine(temp, fileName);
+
+            return fileSystem.CreateDisposableDirectory(path, out directoryInfo);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="DisposableDirectory"/> using the provided <paramref name="path"/>.
+        /// </summary>
+        /// <param name="fileSystem">
+        /// The <see cref="IFileSystem"/> in use.
+        /// </param>
+        /// <param name="path">
+        /// The full path to the directory to create.
+        /// </param>
+        /// <param name="directoryInfo">
+        /// The <see cref="IDirectoryInfo"/> for the directory that was craeted.
+        /// </param>
+        /// <returns>
+        /// A <see cref="DisposableDirectory"/> to manage the directory's lifetime.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// If the directory already exists.
+        /// </exception>
+        public static DisposableDirectory CreateDisposableDirectory(this IFileSystem fileSystem, string path, out IDirectoryInfo directoryInfo)
+        {
+            directoryInfo = fileSystem.DirectoryInfo.New(path);
+
+            if (directoryInfo.Exists)
+            {
+                // Having the colliding path availabe as part of the exception is very useful for debugging.
+                // However, paths can be considered sensitive information in some contexts (like web servers).
+                // Thus, we add the path to the exception's data , rather than the message.
+                var ex = new ArgumentException("Directory already exists", nameof(path));
+                ex.Data.Add("path", path);
+
+                throw ex;
+            }
+
+            directoryInfo.Create();
+
+            // Do an attribute refresh so that the object we return to the caller
+            // has up-to-date properties (like Exists).
+            directoryInfo.Refresh();
+
+            return new DisposableDirectory(directoryInfo);
+        }
     }
 }

--- a/src/System.IO.Abstractions.Extensions/IFileSystemExtensions.cs
+++ b/src/System.IO.Abstractions.Extensions/IFileSystemExtensions.cs
@@ -13,7 +13,8 @@
         }
 
         /// <summary>
-        /// Creates a new <see cref="DisposableDirectory"/> using a random name from the temp path.
+        /// Creates a new <see cref="IDirectoryInfo"/> using a random name from the temp path, and returns an <see cref="IDisposable"/>
+        /// that deletes the directory when disposed.
         /// </summary>
         /// <param name="fileSystem">
         /// The <see cref="IFileSystem"/> in use.
@@ -22,9 +23,9 @@
         /// The <see cref="IDirectoryInfo"/> for the directory that was created.
         /// </param>
         /// <returns>
-        /// A <see cref="DisposableDirectory"/> to manage the directory's lifetime.
+        /// An <see cref="IDisposable"/> to manage the directory's lifetime.
         /// </returns>
-        public static DisposableDirectory CreateDisposableDirectory(this IFileSystem fileSystem, out IDirectoryInfo directoryInfo)
+        public static IDisposable CreateDisposableDirectory(this IFileSystem fileSystem, out IDirectoryInfo directoryInfo)
         {
             var temp = fileSystem.Path.GetTempPath();
             var fileName = fileSystem.Path.GetRandomFileName();
@@ -33,25 +34,14 @@
             return fileSystem.CreateDisposableDirectory(path, out directoryInfo);
         }
 
-        /// <summary>
-        /// Creates a new <see cref="DisposableDirectory"/> using the provided <paramref name="path"/>.
-        /// </summary>
-        /// <param name="fileSystem">
-        /// The <see cref="IFileSystem"/> in use.
-        /// </param>
+        /// <inheritdoc cref="CreateDisposableDirectory(IFileSystem, out IDirectoryInfo)"/>
         /// <param name="path">
         /// The full path to the directory to create.
         /// </param>
-        /// <param name="directoryInfo">
-        /// The <see cref="IDirectoryInfo"/> for the directory that was craeted.
-        /// </param>
-        /// <returns>
-        /// A <see cref="DisposableDirectory"/> to manage the directory's lifetime.
-        /// </returns>
         /// <exception cref="ArgumentException">
         /// If the directory already exists.
         /// </exception>
-        public static DisposableDirectory CreateDisposableDirectory(this IFileSystem fileSystem, string path, out IDirectoryInfo directoryInfo)
+        public static IDisposable CreateDisposableDirectory(this IFileSystem fileSystem, string path, out IDirectoryInfo directoryInfo)
         {
             directoryInfo = fileSystem.DirectoryInfo.New(path);
 
@@ -70,7 +60,8 @@
         }
 
         /// <summary>
-        /// Creates a new <see cref="DisposableFile"/> using a random name from the temp path.
+        /// Creates a new <see cref="IFileInfo"/> using a random name from the temp path, and returns an <see cref="IDisposable"/>
+        /// that deletes the file when disposed.
         /// </summary>
         /// <param name="fileSystem">
         /// The <see cref="IFileSystem"/> in use.
@@ -79,9 +70,9 @@
         /// The <see cref="IFileInfo"/> for the file that was created.
         /// </param>
         /// <returns>
-        /// A <see cref="DisposableFile"/> to manage the file's lifetime.
+        /// An <see cref="IDisposable"/> to manage the file's lifetime.
         /// </returns>
-        public static DisposableFile CreateDisposableFile(this IFileSystem fileSystem, out IFileInfo fileInfo)
+        public static IDisposable CreateDisposableFile(this IFileSystem fileSystem, out IFileInfo fileInfo)
         {
             var temp = fileSystem.Path.GetTempPath();
             var fileName = fileSystem.Path.GetRandomFileName();
@@ -90,25 +81,14 @@
             return fileSystem.CreateDisposableFile(path, out fileInfo);
         }
 
-        /// <summary>
-        /// Creates a new <see cref="DisposableFile"/> using the provided <paramref name="path"/>.
-        /// </summary>
-        /// <param name="fileSystem">
-        /// The <see cref="IFileSystem"/> in use.
-        /// </param>
+        /// <inheritdoc cref="CreateDisposableFile(IFileSystem, out IFileInfo)"/>
         /// <param name="path">
         /// The full path to the file to create.
         /// </param>
-        /// <param name="fileInfo">
-        /// The <see cref="IFileInfo"/> for the file that was craeted.
-        /// </param>
-        /// <returns>
-        /// A <see cref="DisposableFile"/> to manage the file's lifetime.
-        /// </returns>
         /// <exception cref="ArgumentException">
         /// If the file already exists.
         /// </exception>
-        public static DisposableFile CreateDisposableFile(this IFileSystem fileSystem, string path, out IFileInfo fileInfo)
+        public static IDisposable CreateDisposableFile(this IFileSystem fileSystem, string path, out IFileInfo fileInfo)
         {
             fileInfo = fileSystem.FileInfo.New(path);
 

--- a/src/System.IO.Abstractions.Extensions/IFileSystemExtensions.cs
+++ b/src/System.IO.Abstractions.Extensions/IFileSystemExtensions.cs
@@ -39,6 +39,20 @@
         /// </exception>
         public static IDisposable CreateDisposableDirectory(this IFileSystem fileSystem, string path, out IDirectoryInfo directoryInfo)
         {
+            return fileSystem.CreateDisposableDirectory(path, dir => new DisposableDirectory(dir), out directoryInfo);
+        }
+
+        /// <inheritdoc cref="CreateDisposableDirectory(IFileSystem, string, out IDirectoryInfo)"/>
+        /// <param name="disposableFactory">
+        /// A <see cref="Func{T, TResult}"/> that acts as a factory method. Given the <see cref="IDirectoryInfo"/>, create the
+        /// <see cref="IDisposable"/> that will manage the its lifetime.
+        /// </param>
+        public static T CreateDisposableDirectory<T>(
+            this IFileSystem fileSystem,
+            string path,
+            Func<IDirectoryInfo, T> disposableFactory,
+            out IDirectoryInfo directoryInfo) where T : IDisposable
+        {
             directoryInfo = fileSystem.DirectoryInfo.New(path);
 
             if (directoryInfo.Exists)
@@ -48,7 +62,7 @@
 
             directoryInfo.Create();
 
-            return new DisposableDirectory(directoryInfo);
+            return disposableFactory(directoryInfo);
         }
 
         /// <summary>
@@ -78,6 +92,20 @@
         /// </exception>
         public static IDisposable CreateDisposableFile(this IFileSystem fileSystem, string path, out IFileInfo fileInfo)
         {
+            return fileSystem.CreateDisposableFile(path, file => new DisposableFile(file), out fileInfo);
+        }
+
+        /// <inheritdoc cref="CreateDisposableFile(IFileSystem, string, out IFileInfo)"/>
+        /// <param name="disposableFactory">
+        /// A <see cref="Func{T, TResult}"/> that acts as a factory method. Given the <see cref="IFileInfo"/>, create the
+        /// <see cref="IDisposable"/> that will manage the its lifetime.
+        /// </param>
+        public static T CreateDisposableFile<T>(
+            this IFileSystem fileSystem,
+            string path,
+            Func<IFileInfo, T> disposableFactory,
+            out IFileInfo fileInfo) where T : IDisposable
+        {
             fileInfo = fileSystem.FileInfo.New(path);
 
             if (fileInfo.Exists)
@@ -89,7 +117,7 @@
             // callers may get an access denied error.
             fileInfo.Create().Dispose();
 
-            return new DisposableFile(fileInfo);
+            return disposableFactory(fileInfo);
         }
 
         private static string GetRandomTempPath(this IPath path)

--- a/tests/System.IO.Abstractions.Extensions.Tests/DisposableDirectoryTests.cs
+++ b/tests/System.IO.Abstractions.Extensions.Tests/DisposableDirectoryTests.cs
@@ -24,6 +24,7 @@ namespace System.IO.Abstractions.Extensions.Tests
 
             // Assert directory exists
             Assert.IsTrue(fs.Directory.Exists(path), "Directory should exist");
+            Assert.IsTrue(dirInfo.Exists, "IDirectoryInfo.Exists should be true");
 
             // Act
             var disposableDirectory = new DisposableDirectory(dirInfo);
@@ -31,6 +32,7 @@ namespace System.IO.Abstractions.Extensions.Tests
 
             // Assert directory is deleted
             Assert.IsFalse(fs.Directory.Exists(path), "Directory should not exist");
+            Assert.IsFalse(dirInfo.Exists, "IDirectoryInfo.Exists should be false");
 
             // Assert a second dispose does not throw
             Assert.DoesNotThrow(() => disposableDirectory.Dispose());

--- a/tests/System.IO.Abstractions.Extensions.Tests/DisposableDirectoryTests.cs
+++ b/tests/System.IO.Abstractions.Extensions.Tests/DisposableDirectoryTests.cs
@@ -1,0 +1,39 @@
+﻿using NUnit.Framework;
+
+namespace System.IO.Abstractions.Extensions.Tests
+{
+    [TestFixture]
+    public class DisposableDirectoryTests
+    {
+        [Test]
+        public void DisposableDirectory_Throws_ArgumentNullException_For_Null_IDirectoryInfo_Test()
+        {
+            Assert.Throws<ArgumentNullException>(() => new DisposableDirectory(null!));
+        }
+
+        [Test]
+        public void DisposableDirectory_DeleteRecursive_On_Dispose_Test()
+        {
+            // Arrange
+            var fs = new FileSystem();
+            var path = fs.Path.Combine(fs.Directory.GetCurrentDirectory(), fs.Path.GetRandomFileName());
+            var dirInfo = fs.DirectoryInfo.New(path);
+
+            // Create a subdirectory to ensure recursive delete
+            dirInfo.CreateSubdirectory(Guid.NewGuid().ToString());
+
+            // Assert directory exists
+            Assert.IsTrue(fs.Directory.Exists(path), "Directory should exist");
+
+            // Act
+            var disposableDirectory = new DisposableDirectory(dirInfo);
+            disposableDirectory.Dispose();
+
+            // Assert directory is deleted
+            Assert.IsFalse(fs.Directory.Exists(path), "Directory should not exist");
+
+            // Assert a second dispose does not throw
+            Assert.DoesNotThrow(() => disposableDirectory.Dispose());
+        }
+    }
+}

--- a/tests/System.IO.Abstractions.Extensions.Tests/DisposableFileTests.cs
+++ b/tests/System.IO.Abstractions.Extensions.Tests/DisposableFileTests.cs
@@ -1,0 +1,37 @@
+﻿using NUnit.Framework;
+
+namespace System.IO.Abstractions.Extensions.Tests
+{
+    [TestFixture]
+    public class DisposableFileTests
+    {
+        [Test]
+        public void DisposableFile_Throws_ArgumentNullException_For_Null_IFileInfo_Test()
+        {
+            Assert.Throws<ArgumentNullException>(() => new DisposableFile(null!));
+        }
+
+        [Test]
+        public void DisposableFile_Delete_On_Dispose_Test()
+        {
+            // Arrange
+            var fs = new FileSystem();
+            var path = fs.Path.Combine(fs.Directory.GetCurrentDirectory(), fs.Path.GetRandomFileName());
+            var fileInfo = fs.FileInfo.New(path);
+            fileInfo.Create().Dispose();
+
+            // Assert file exists
+            Assert.IsTrue(fs.File.Exists(path), "File exists");
+
+            // Act
+            var disposableFile = new DisposableFile(fileInfo);
+            disposableFile.Dispose();
+
+            // Assert directory is deleted
+            Assert.IsFalse(fs.File.Exists(path), "File does not exist");
+
+            // Assert a second dispose does not throw
+            Assert.DoesNotThrow(() => disposableFile.Dispose());
+        }
+    }
+}

--- a/tests/System.IO.Abstractions.Extensions.Tests/DisposableFileTests.cs
+++ b/tests/System.IO.Abstractions.Extensions.Tests/DisposableFileTests.cs
@@ -1,5 +1,4 @@
 ﻿using NUnit.Framework;
-using System.Runtime;
 
 namespace System.IO.Abstractions.Extensions.Tests
 {

--- a/tests/System.IO.Abstractions.Extensions.Tests/DisposableFileTests.cs
+++ b/tests/System.IO.Abstractions.Extensions.Tests/DisposableFileTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using System.Runtime;
 
 namespace System.IO.Abstractions.Extensions.Tests
 {
@@ -22,6 +23,7 @@ namespace System.IO.Abstractions.Extensions.Tests
 
             // Assert file exists
             Assert.IsTrue(fs.File.Exists(path), "File exists");
+            Assert.IsTrue(fileInfo.Exists, "IFileInfo.Exists should be true");
 
             // Act
             var disposableFile = new DisposableFile(fileInfo);
@@ -29,6 +31,7 @@ namespace System.IO.Abstractions.Extensions.Tests
 
             // Assert directory is deleted
             Assert.IsFalse(fs.File.Exists(path), "File does not exist");
+            Assert.IsFalse(fileInfo.Exists, "IFileInfo.Exists should be false");
 
             // Assert a second dispose does not throw
             Assert.DoesNotThrow(() => disposableFile.Dispose());

--- a/tests/System.IO.Abstractions.Extensions.Tests/FileSystemExtensionsTests.cs
+++ b/tests/System.IO.Abstractions.Extensions.Tests/FileSystemExtensionsTests.cs
@@ -14,5 +14,44 @@ namespace System.IO.Abstractions.Extensions.Tests
             Assert.IsFalse(String.IsNullOrWhiteSpace(fullName));
             Assert.AreEqual(Environment.CurrentDirectory, fullName);
         }
+
+        [Test]
+        public void CreateDisposableDirectory_Temp_Path_Test()
+        {
+            // Arrange
+            var fs = new FileSystem();
+            string path;
+
+            // Act
+            using (_ = fs.CreateDisposableDirectory(out var dir))
+            {
+                path = dir.FullName;
+
+                Assert.IsTrue(dir.Exists, "Directory should exist");
+                Assert.IsTrue(
+                    path.StartsWith(fs.Path.GetTempPath(), StringComparison.Ordinal),
+                    "Directory should be in temp path");
+            }
+
+            // Assert directory is deleted
+            Assert.IsFalse(fs.Directory.Exists(path), "Directory should not exist");
+        }
+
+        [Test]
+        public void CreateDisposableDirectory_Already_Exists_Test()
+        {
+            // Arrange
+            var fs = new FileSystem();
+            var path = fs.Path.Combine(fs.Path.GetTempPath(), fs.Path.GetRandomFileName());
+            fs.Directory.CreateDirectory(path);
+
+            // Assert
+            var ex = Assert.Throws<ArgumentException>(() => fs.CreateDisposableDirectory(path, out _));
+            Assert.True(ex.Data["path"].ToString() == path, "Exception data should contain colliding path to aid with debugging");
+
+            // Delete colliding directory
+            fs.Directory.Delete(path);
+            Assert.IsFalse(fs.Directory.Exists(path), "Directory should not exist");
+        }
     }
 }

--- a/tests/System.IO.Abstractions.Extensions.Tests/FileSystemExtensionsTests.cs
+++ b/tests/System.IO.Abstractions.Extensions.Tests/FileSystemExtensionsTests.cs
@@ -53,5 +53,44 @@ namespace System.IO.Abstractions.Extensions.Tests
             fs.Directory.Delete(path);
             Assert.IsFalse(fs.Directory.Exists(path), "Directory should not exist");
         }
+
+        [Test]
+        public void CreateDisposableFile_Temp_Path_Test()
+        {
+            // Arrange
+            var fs = new FileSystem();
+            string path;
+
+            // Act
+            using (_ = fs.CreateDisposableFile(out var file))
+            {
+                path = file.FullName;
+
+                Assert.IsTrue(file.Exists, "File should exist");
+                Assert.IsTrue(
+                    path.StartsWith(fs.Path.GetTempPath(), StringComparison.Ordinal),
+                    "File should be in temp path");
+            }
+
+            // Assert file is deleted
+            Assert.IsFalse(fs.File.Exists(path), "File should not exist");
+        }
+
+        [Test]
+        public void CreateDisposableFile_Already_Exists_Test()
+        {
+            // Arrange
+            var fs = new FileSystem();
+            var path = fs.Path.Combine(fs.Path.GetTempPath(), fs.Path.GetRandomFileName());
+            fs.File.Create(path).Dispose();
+
+            // Assert
+            var ex = Assert.Throws<ArgumentException>(() => fs.CreateDisposableFile(path, out _));
+            Assert.True(ex.Data["path"].ToString() == path, "Exception data should contain colliding path to aid with debugging");
+
+            // Delete colliding file
+            fs.File.Delete(path);
+            Assert.IsFalse(fs.File.Exists(path), "File should not exist");
+        }
     }
 }


### PR DESCRIPTION
Add two new extension methods on `IFileSystem`:

- CreateDisposableDirectory
- CreateDisposableFile

Each creates a file / directory and returns it via an `out` param and returns an instance of `IDisposable` so that a `using` statement will automatically delete the file when the block goes out of scope.

An overload is also provided that automatically creates a uniquely named file using the file system's temp path and random file name.

Another overload is provided that takes a `Func` of the `IFileInfo` / `IDirectoryInfo` and returns the corresponding `IDisposable` implementation. This allows callers to provide a custom implementation of `IDisposable` to do things like:

- Assert the directory is empty before deleting
- Do a non-recursive delete for directories
- Intentionally "leak" the file / directory to aid in debugging

As a result, the `DisposableFile`, `DisposableDirectory`, and `DisposableFileSystemInfo` classes are all public to allow for inheritance. Note however that the extension methods only return `IDisposable`, so most callers will not encounter them.

Unit tests also added to verify functionality.

Fixes #40 