### PR TITLE
feat: Improve CopyTo directory extension to allow overwrites

### DIFF
--- a/src/System.IO.Abstractions.Extensions/IDirectoryInfoExtensions.cs
+++ b/src/System.IO.Abstractions.Extensions/IDirectoryInfoExtensions.cs
@@ -207,9 +207,9 @@ namespace System.IO.Abstractions
             this IDirectoryInfo source,
             IDirectoryInfo destination,
             bool recursive = false,
-            bool overwrite = false,
             string filesSearchPattern = "*",
-            string directoriesSearchPattern = "*")
+            string directoriesSearchPattern = "*",
+            bool overwrite = false)
         {
             if (!overwrite)
             {

--- a/src/System.IO.Abstractions.Extensions/IDirectoryInfoExtensions.cs
+++ b/src/System.IO.Abstractions.Extensions/IDirectoryInfoExtensions.cs
@@ -199,18 +199,20 @@ namespace System.IO.Abstractions
         /// </summary>
         /// <param name="source">Source directory</param>
         /// <param name="destination">Destination directory</param>
-        /// <param name="recursive">If true the copy will be recursive and will include subfolders of <paramref name="info"/>. Defaults to false</param>
+        /// <param name="recursive">If true the copy will be recursive and will include subfolders of <paramref name="source"/>. Defaults to false</param>
+        /// <param name="overwrite">If true the copy will overwrite any existing files in <paramref name="destination"/>. Defaults to false</param>
         /// <param name="filesSearchPattern">Search pattern to apply when searching files, defaults to '*'</param>
         /// <param name="directoriesSearchPattern">Search pattern to apply when searching directories, defaults to '*'</param>
         public static void CopyTo(
             this IDirectoryInfo source,
             IDirectoryInfo destination,
             bool recursive = false,
+            bool overwrite = false,
             string filesSearchPattern = "*",
             string directoriesSearchPattern = "*")
         {
             source.ForEachFile(
-                (file, destDir) => file.CopyTo(destDir.GetFilePath(file.Name)),
+                (file, destDir) => file.CopyTo(destDir.GetFilePath(file.Name), overwrite),
                 subDirectory => source.TranslatePaths(subDirectory, destination, true),
                 recursive,
                 filesSearchPattern,

--- a/src/System.IO.Abstractions.Extensions/IDirectoryInfoExtensions.cs
+++ b/src/System.IO.Abstractions.Extensions/IDirectoryInfoExtensions.cs
@@ -211,22 +211,6 @@ namespace System.IO.Abstractions
             string directoriesSearchPattern = "*",
             bool overwrite = false)
         {
-            if (!overwrite)
-            {
-                source.ForEachFile(
-                    (file, destDir) => {
-                        var destPath = destDir.GetFilePath(file.Name);
-                        if (destination.FileSystem.File.Exists(destPath))
-                        {
-                            throw new IOException(StringResources.Format("CANNOT_OVERWRITE", destPath));
-                        }
-                    },
-                    subDirectory => source.TranslatePaths(subDirectory, destination, true),
-                    recursive,
-                    filesSearchPattern,
-                    directoriesSearchPattern);
-            }
-
             source.ForEachFile(
                 (file, destDir) => file.CopyTo(destDir.GetFilePath(file.Name), overwrite),
                 subDirectory => source.TranslatePaths(subDirectory, destination, true),

--- a/src/System.IO.Abstractions.Extensions/IDirectoryInfoExtensions.cs
+++ b/src/System.IO.Abstractions.Extensions/IDirectoryInfoExtensions.cs
@@ -211,6 +211,22 @@ namespace System.IO.Abstractions
             string filesSearchPattern = "*",
             string directoriesSearchPattern = "*")
         {
+            if (!overwrite)
+            {
+                source.ForEachFile(
+                    (file, destDir) => {
+                        var destPath = destDir.GetFilePath(file.Name);
+                        if (destination.FileSystem.File.Exists(destPath))
+                        {
+                            throw new IOException(StringResources.Format("CANNOT_OVERWRITE", destPath));
+                        }
+                    },
+                    subDirectory => source.TranslatePaths(subDirectory, destination, true),
+                    recursive,
+                    filesSearchPattern,
+                    directoriesSearchPattern);
+            }
+
             source.ForEachFile(
                 (file, destDir) => file.CopyTo(destDir.GetFilePath(file.Name), overwrite),
                 subDirectory => source.TranslatePaths(subDirectory, destination, true),

--- a/tests/System.IO.Abstractions.Extensions.Tests/DirectoryInfoExtensionsTests.cs
+++ b/tests/System.IO.Abstractions.Extensions.Tests/DirectoryInfoExtensionsTests.cs
@@ -390,7 +390,7 @@ namespace System.IO.Abstractions.Extensions.Tests
         }
 
         [Test]
-        public void CopyTo_Overwrite_OverwritesWhenSet([Values] bool preExisting)
+        public void CopyTo_Overwrite_OverwritesWhenSet()
         {
             //arrange
             var fs = new FileSystem();
@@ -410,25 +410,15 @@ namespace System.IO.Abstractions.Extensions.Tests
             var sourceFileContent = new[] { nameof(sourceFile) };
             sourceFile.WriteLines(sourceFileContent);
             var destFileContent = new[] { nameof(destFile) };
-            if (preExisting)
-            {
-                destFile.WriteLines(destFileContent);
-            }
+            destFile.WriteLines(destFileContent);
 
             //make sure everything is set up as expected
             Assert.IsTrue(fs.Directory.Exists(source.FullName));
             Assert.IsTrue(fs.File.Exists(sourceFile.FullName));
             Assert.AreEqual(fs.File.ReadAllLines(sourceFile.FullName), sourceFileContent);
             Assert.IsTrue(fs.Directory.Exists(dest.FullName));
-            if (preExisting)
-            {
-                Assert.IsTrue(fs.File.Exists(destFile.FullName));
-                Assert.AreEqual(fs.File.ReadAllLines(destFile.FullName), destFileContent);
-            }
-            else
-            {
-                Assert.IsFalse(fs.File.Exists(destFile.FullName));
-            }
+            Assert.IsTrue(fs.File.Exists(destFile.FullName));
+            Assert.AreEqual(fs.File.ReadAllLines(destFile.FullName), destFileContent);
 
             //act
             source.CopyTo(dest, overwrite: true);
@@ -443,7 +433,7 @@ namespace System.IO.Abstractions.Extensions.Tests
         }
 
         [Test]
-        public void CopyTo_Overwrite_DoesNotOverwriteSingleFileWhenNotSet()
+        public void CopyTo_Overwrite_DoesNotOverwritesWhenNotSet()
         {
             //arrange
             var fs = new FileSystem();
@@ -478,56 +468,6 @@ namespace System.IO.Abstractions.Extensions.Tests
 
             //assert
             Assert.AreEqual(fs.File.ReadAllLines(destFile.FullName), destFileContent);
-
-            //cleanup
-            workingDir.Delete(recursive: true);
-
-            Assert.IsFalse(fs.File.Exists(workingDir.FullName));
-        }
-
-        [Test]
-        public void CopyTo_Overwrite_DoesNotOverwriteMultipleFilesWhenNotSet()
-        {
-            //arrange
-            var fs = new FileSystem();
-            var workingDir = fs.DirectoryInfo.New(fs.Directory.GetCurrentDirectory()).CreateSubdirectory(Guid.NewGuid().ToString());
-
-            //create directories
-            var source = fs.DirectoryInfo.New(fs.Path.Combine(workingDir.FullName, "SourceDir"));
-            var dest = fs.DirectoryInfo.New(fs.Path.Combine(workingDir.FullName, "DestDir"));
-
-            source.Create();
-            dest.Create();
-
-            //create files
-            var sourceFile = fs.FileInfo.New(fs.Path.Combine(source.FullName, "file.txt"));
-            var secondSourceFile = fs.FileInfo.New(fs.Path.Combine(source.FullName, "another.txt")); // This will show up alphabetically first
-            var destFile = fs.FileInfo.New(fs.Path.Combine(dest.FullName, "file.txt"));
-            var secondDestFile = fs.FileInfo.New(fs.Path.Combine(dest.FullName, "another.txt"));
-
-            var sourceFileContent = new[] { nameof(sourceFile) };
-            sourceFile.WriteLines(sourceFileContent);
-            secondSourceFile.WriteLines(sourceFileContent);
-            var destFileContent = new[] { nameof(destFile) };
-            destFile.WriteLines(destFileContent);
-
-            //make sure everything is set up as expected
-            Assert.IsTrue(fs.Directory.Exists(source.FullName));
-            Assert.IsTrue(fs.File.Exists(sourceFile.FullName));
-            Assert.AreEqual(fs.File.ReadAllLines(sourceFile.FullName), sourceFileContent);
-            Assert.IsTrue(fs.File.Exists(secondSourceFile.FullName));
-            Assert.AreEqual(fs.File.ReadAllLines(secondSourceFile.FullName), sourceFileContent);
-            Assert.IsTrue(fs.Directory.Exists(dest.FullName));
-            Assert.IsTrue(fs.File.Exists(destFile.FullName));
-            Assert.AreEqual(fs.File.ReadAllLines(destFile.FullName), destFileContent);
-            Assert.IsFalse(fs.File.Exists(secondDestFile.FullName));
-
-            //act
-            Assert.That(() => source.CopyTo(dest, overwrite: false), Throws.Exception.TypeOf<IOException>().And.Message.Contains(destFile.FullName));
-
-            //assert
-            Assert.AreEqual(fs.File.ReadAllLines(destFile.FullName), destFileContent);
-            Assert.IsFalse(fs.File.Exists(secondDestFile.FullName));
 
             //cleanup
             workingDir.Delete(recursive: true);

--- a/tests/System.IO.Abstractions.Extensions.Tests/DirectoryInfoExtensionsTests.cs
+++ b/tests/System.IO.Abstractions.Extensions.Tests/DirectoryInfoExtensionsTests.cs
@@ -388,5 +388,91 @@ namespace System.IO.Abstractions.Extensions.Tests
 
             Assert.IsFalse(fs.File.Exists(workingDir.FullName));
         }
+
+        [Test]
+        public void CopyTo_Overwrite_OverwritesWhenSet()
+        {
+            //arrange
+            var fs = new FileSystem();
+            var workingDir = fs.DirectoryInfo.New(fs.Directory.GetCurrentDirectory()).CreateSubdirectory(Guid.NewGuid().ToString());
+
+            //create directories
+            var source = fs.DirectoryInfo.New(fs.Path.Combine(workingDir.FullName, "SourceDir"));
+            var dest = fs.DirectoryInfo.New(fs.Path.Combine(workingDir.FullName, "DestDir"));
+
+            source.Create();
+            dest.Create();
+
+            //create files
+            var sourceFile = fs.FileInfo.New(fs.Path.Combine(source.FullName, "file.txt"));
+            var destFile = fs.FileInfo.New(fs.Path.Combine(dest.FullName, "file.txt"));
+
+            var sourceFileContent = new[] { nameof(sourceFile) };
+            sourceFile.WriteLines(sourceFileContent);
+            var destFileContent = new[] { nameof(destFile) };
+            destFile.WriteLines(destFileContent);
+
+            //make sure everything is set up as expected
+            Assert.IsTrue(fs.Directory.Exists(source.FullName));
+            Assert.IsTrue(fs.File.Exists(sourceFile.FullName));
+            Assert.AreEqual(fs.File.ReadAllLines(sourceFile.FullName), sourceFileContent);
+            Assert.IsTrue(fs.Directory.Exists(dest.FullName));
+            Assert.IsTrue(fs.File.Exists(destFile.FullName));
+            Assert.AreEqual(fs.File.ReadAllLines(destFile.FullName), destFileContent);
+
+            //act
+            source.CopyTo(dest, overwrite: true);
+
+            //assert
+            Assert.AreEqual(fs.File.ReadAllLines(destFile.FullName), sourceFileContent);
+
+            //cleanup
+            workingDir.Delete(recursive: true);
+
+            Assert.IsFalse(fs.File.Exists(workingDir.FullName));
+        }
+
+        [Test]
+        public void CopyTo_Overwrite_DoesNotOverwritesWhenNotSet()
+        {
+            //arrange
+            var fs = new FileSystem();
+            var workingDir = fs.DirectoryInfo.New(fs.Directory.GetCurrentDirectory()).CreateSubdirectory(Guid.NewGuid().ToString());
+
+            //create directories
+            var source = fs.DirectoryInfo.New(fs.Path.Combine(workingDir.FullName, "SourceDir"));
+            var dest = fs.DirectoryInfo.New(fs.Path.Combine(workingDir.FullName, "DestDir"));
+
+            source.Create();
+            dest.Create();
+
+            //create files
+            var sourceFile = fs.FileInfo.New(fs.Path.Combine(source.FullName, "file.txt"));
+            var destFile = fs.FileInfo.New(fs.Path.Combine(dest.FullName, "file.txt"));
+
+            var sourceFileContent = new[] { nameof(sourceFile) };
+            sourceFile.WriteLines(sourceFileContent);
+            var destFileContent = new[] { nameof(destFile) };
+            destFile.WriteLines(destFileContent);
+
+            //make sure everything is set up as expected
+            Assert.IsTrue(fs.Directory.Exists(source.FullName));
+            Assert.IsTrue(fs.File.Exists(sourceFile.FullName));
+            Assert.AreEqual(fs.File.ReadAllLines(sourceFile.FullName), sourceFileContent);
+            Assert.IsTrue(fs.Directory.Exists(dest.FullName));
+            Assert.IsTrue(fs.File.Exists(destFile.FullName));
+            Assert.AreEqual(fs.File.ReadAllLines(destFile.FullName), destFileContent);
+
+            //act
+            Assert.That(() => source.CopyTo(dest, overwrite: false), Throws.Exception.TypeOf<IOException>().And.Message.Contains(destFile.FullName));
+
+            //assert
+            Assert.AreEqual(fs.File.ReadAllLines(destFile.FullName), destFileContent);
+
+            //cleanup
+            workingDir.Delete(recursive: true);
+
+            Assert.IsFalse(fs.File.Exists(workingDir.FullName));
+        }
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.1",
+  "version": "2.2",
   "assemblyVersion": {
     "precision": "major"
   },


### PR DESCRIPTION
Using the `IDirectoryInfoExtensions.CopyTo` method is very useful, however it doesn't support overwriting files. This resulted in a modified copy of this within my own code. It also raised the question of when it fails due to a file already existing the destination directory is left with files partially copied.

This PR implements both passing the `overwrite` argument, and additional checks to prevent only a partial copy succeeding. If the copy is likely to fail on a first pass to evaluate file existence, then no files are copied. This doesn't account for the slightly trickier case of files being locked or permissions not permitting writing within the directory tree. It didn't seem sensible to implement one without the other.

Hopefully this would allow the function within the library to be even more useful whilst providing a sensible guardrail. My hesitation with this approach is that it would change the behaviour of the function from doing a partial copy to no copy where files already exist in the destination (a behaviour I'd really hope no one relies on). It does also cause a binary compatibility issue to the addition of an optional argument to an existing method (a behaviour I'm much more concerned by, maybe making this warranting of a major version bump).

Sorry for not opening as an issue for discussion first, but I felt the code probably articulated what I was trying to say a bit better.