### PR TITLE
feat: Add temp path overload for DisposableFileSystem extensions

### DIFF
--- a/src/System.IO.Abstractions.Extensions/IFileSystemExtensions.cs
+++ b/src/System.IO.Abstractions.Extensions/IFileSystemExtensions.cs
@@ -55,6 +55,23 @@ namespace System.IO.Abstractions
             return fileSystem.CreateDisposableDirectory(path, dir => new DisposableDirectory(dir), out directoryInfo);
         }
 
+        /// <inheritdoc cref="CreateDisposableDirectory(IFileSystem, out IDirectoryInfo)"/>
+        /// <summary>
+        /// Creates a new <see cref="IDirectoryInfo"/> using a random name from the temp path and returns an
+        /// <see cref="IDisposable"/> created by <paramref name="disposableFactory"/>, that should delete the directory when disposed.
+        /// </summary>
+        /// <param name="disposableFactory">
+        /// A <see cref="Func{T, TResult}"/> that acts as a factory method. Given the <see cref="IDirectoryInfo"/>, create the
+        /// <see cref="IDisposable"/> that will manage the its lifetime.
+        /// </param>
+        public static T CreateDisposableDirectory<T>(
+            this IFileSystem fileSystem,
+            Func<IDirectoryInfo, T> disposableFactory,
+            out IDirectoryInfo directoryInfo) where T : IDisposable
+        {
+            return fileSystem.CreateDisposableDirectory(fileSystem.Path.GetRandomTempPath(), disposableFactory, out directoryInfo);
+        }
+
         /// <inheritdoc cref="CreateDisposableDirectory(IFileSystem, string, out IDirectoryInfo)"/>
         /// <summary>
         /// Creates a new <see cref="IDirectoryInfo"/> using a path provided by <paramref name="path"/>, and returns an
@@ -114,6 +131,23 @@ namespace System.IO.Abstractions
         public static IDisposable CreateDisposableFile(this IFileSystem fileSystem, string path, out IFileInfo fileInfo)
         {
             return fileSystem.CreateDisposableFile(path, file => new DisposableFile(file), out fileInfo);
+        }
+
+        /// <inheritdoc cref="CreateDisposableFile(IFileSystem, out IFileInfo)"/>
+        /// <summary>
+        /// Creates a new <see cref="IFileInfo"/> using a random name from the temp path and returns an
+        /// <see cref="IDisposable"/> created by <paramref name="disposableFactory"/>, that should delete the file when disposed.
+        /// </summary>
+        /// <param name="disposableFactory">
+        /// A <see cref="Func{T, TResult}"/> that acts as a factory method. Given the <see cref="IFileInfo"/>, create the
+        /// <see cref="IDisposable"/> that will manage the its lifetime.
+        /// </param>
+        public static T CreateDisposableFile<T>(
+            this IFileSystem fileSystem,
+            Func<IFileInfo, T> disposableFactory,
+            out IFileInfo fileInfo) where T : IDisposable
+        {
+            return fileSystem.CreateDisposableFile(fileSystem.Path.GetRandomTempPath(), disposableFactory, out fileInfo);
         }
 
         /// <inheritdoc cref="CreateDisposableFile(IFileSystem, string, out IFileInfo)"/>

--- a/tests/System.IO.Abstractions.Extensions.Tests/FileSystemExtensionsTests.cs
+++ b/tests/System.IO.Abstractions.Extensions.Tests/FileSystemExtensionsTests.cs
@@ -89,11 +89,11 @@ namespace System.IO.Abstractions.Extensions.Tests
         {
             // Arrange
             var fs = new FileSystem();
-            var path = fs.Path.Combine(fs.Path.GetTempPath(), fs.Path.GetRandomFileName());
+            string path = null;
 
             // Act
             CustomDisposableDirectory customDisposable;
-            using (customDisposable = fs.CreateDisposableDirectory(path, dir => new CustomDisposableDirectory(dir), out var dirInfo))
+            using (customDisposable = fs.CreateDisposableDirectory(dir => new CustomDisposableDirectory(dir), out var dirInfo))
             {
                 path = dirInfo.FullName;
 
@@ -102,6 +102,7 @@ namespace System.IO.Abstractions.Extensions.Tests
             }
 
             // Assert directory is deleted
+            Assert.IsNotNull(path);
             Assert.IsFalse(fs.Directory.Exists(path), "Directory should not exist");
             Assert.IsTrue(customDisposable.DeleteFileSystemInfoWasCalled, "Custom disposable delete should have been called");
         }
@@ -150,11 +151,11 @@ namespace System.IO.Abstractions.Extensions.Tests
         {
             // Arrange
             var fs = new FileSystem();
-            var path = fs.Path.Combine(fs.Path.GetTempPath(), fs.Path.GetRandomFileName());
+            string path = null;
 
             // Act
             CustomDisposableFile customDisposable;
-            using (customDisposable = fs.CreateDisposableFile(path, dir => new CustomDisposableFile(dir), out var fileInfo))
+            using (customDisposable = fs.CreateDisposableFile(dir => new CustomDisposableFile(dir), out var fileInfo))
             {
                 path = fileInfo.FullName;
 
@@ -163,6 +164,7 @@ namespace System.IO.Abstractions.Extensions.Tests
             }
 
             // Assert file is deleted
+            Assert.IsNotNull(path);
             Assert.IsFalse(fs.File.Exists(path), "File should not exist");
             Assert.IsTrue(customDisposable.DeleteFileSystemInfoWasCalled, "Custom disposable delete should have been called");
         }


### PR DESCRIPTION
The `CreateDisposableFile` / `CreateDisposableDirectory` extensions provide two overloads, one automatically creates a subdirectory under `%TEMP%`, and the other takes a `string`.

However, the overload that accepts a disposable factory only has one overload that requires a path. In order to make using the extension with custom disposables easier, also provide an overload that automatically creates a subdirectory under `%TEMP%`.

Also updated unit tests to cover the functionality.